### PR TITLE
Allow JSON logins on token endpoint

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -23,7 +23,7 @@ def get_password_hash(password: str) -> str:
 def verify_password(password: str, hashed_pw: str) -> bool:
     return pwd_context.verify(password, hashed_pw)
 
-# สำคัญ: เปลี่ยน tokenUrl ให้ตรงกับ /auth/login (แบบ JSON)
+# tokenUrl สำหรับ OAuth2 (endpoint รองรับทั้ง form และ JSON)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,27 +1,41 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
 from datetime import timedelta
-from fastapi.security import OAuth2PasswordRequestForm
-from .. import database, models, auth, schemas
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from .. import auth, database, models, schemas
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
-@router.post("/token")
-def login_form(form: OAuth2PasswordRequestForm = Depends(),
-               db: Session = Depends(database.SessionLocal)):
-    user = db.query(models.User).filter(models.User.username == form.username).first()
-    if not user or not auth.verify_password(form.password, user.password_hash):
+def _authenticate_and_issue_token(db: Session, username: str, password: str) -> dict:
+    user = db.query(models.User).filter(models.User.username == username).first()
+    if not user or not auth.verify_password(password, user.password_hash):
         raise HTTPException(status_code=400, detail="Incorrect username or password")
+
     expires = timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
     token = auth.create_access_token(data={"sub": user.username}, expires_delta=expires)
     return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/token")
+async def login_form(request: Request,
+                     db: Session = Depends(database.SessionLocal)):
+    """Accept login credentials via form data or JSON payloads."""
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        payload = schemas.UserLogin(**await request.json())
+        return _authenticate_and_issue_token(db, payload.username, payload.password)
+
+    form = await request.form()
+    username = form.get("username")
+    password = form.get("password")
+    if not username or not password:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    return _authenticate_and_issue_token(db, username, password)
+
 
 @router.post("/login")
 def login_json(payload: schemas.UserLogin,
                db: Session = Depends(database.SessionLocal)):
-    user = db.query(models.User).filter(models.User.username == payload.username).first()
-    if not user or not auth.verify_password(payload.password, user.password_hash):
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
-    expires = timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
-    token = auth.create_access_token(data={"sub": user.username}, expires_delta=expires)
-    return {"access_token": token, "token_type": "bearer"}
+    return _authenticate_and_issue_token(db, payload.username, payload.password)


### PR DESCRIPTION
## Summary
- accept both JSON payloads and form submissions on the /auth/token endpoint
- centralize credential validation when issuing tokens
- clarify the OAuth2 password bearer comment to reflect the supported formats

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d15a06afa08328b1e39390a4f3bafb