### PR TITLE
Fix database dependency injection for FastAPI

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -33,7 +33,7 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 def get_current_user(token: str = Depends(oauth2_scheme),
-                     db: Session = Depends(database.SessionLocal)):
+                     db: Session = Depends(database.get_db)):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid credentials",

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,7 +1,9 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
 import os
+from typing import Generator
+
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 load_dotenv()  # โหลด .env
 
@@ -13,3 +15,11 @@ engine = create_engine(
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -19,7 +19,7 @@ def _authenticate_and_issue_token(db: Session, username: str, password: str) -> 
 
 @router.post("/token")
 async def login_form(request: Request,
-                     db: Session = Depends(database.SessionLocal)):
+                     db: Session = Depends(database.get_db)):
     """Accept login credentials via form data or JSON payloads."""
     content_type = request.headers.get("content-type", "")
     if "application/json" in content_type:
@@ -37,5 +37,5 @@ async def login_form(request: Request,
 
 @router.post("/login")
 def login_json(payload: schemas.UserLogin,
-               db: Session = Depends(database.SessionLocal)):
+               db: Session = Depends(database.get_db)):
     return _authenticate_and_issue_token(db, payload.username, payload.password)

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -7,11 +7,11 @@ router = APIRouter(prefix="/news", tags=["News"])
 UPLOAD_DIR = "uploads"
 
 @router.get("/", response_model=list[schemas.NewsBase])
-def get_news(db: Session = Depends(database.SessionLocal)):
+def get_news(db: Session = Depends(database.get_db)):
     return db.query(models.News).order_by(models.News.created_at.desc()).all()
 
 @router.post("/", response_model=schemas.NewsBase)
-def create_news(news: schemas.NewsCreate, db: Session = Depends(database.SessionLocal), current_user: models.User = Depends(auth.get_current_user)):
+def create_news(news: schemas.NewsCreate, db: Session = Depends(database.get_db), current_user: models.User = Depends(auth.get_current_user)):
     new_news = models.News(title=news.title, content=news.content)
     db.add(new_news)
     db.commit()
@@ -19,7 +19,7 @@ def create_news(news: schemas.NewsCreate, db: Session = Depends(database.Session
     return new_news
 
 @router.post("/{news_id}/files", response_model=schemas.FileBase)
-def upload_file(news_id: int, file: UploadFile = File(...), db: Session = Depends(database.SessionLocal), current_user: models.User = Depends(auth.get_current_user)):
+def upload_file(news_id: int, file: UploadFile = File(...), db: Session = Depends(database.get_db), current_user: models.User = Depends(auth.get_current_user)):
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     file_path = os.path.join(UPLOAD_DIR, file.filename)
     with open(file_path, "wb") as buffer:


### PR DESCRIPTION
## Summary
- add a reusable database session dependency that yields and closes SQLAlchemy sessions
- update authentication and news routes to use the new dependency instead of the raw SessionLocal callable

## Testing
- curl -s -o - -w "%{http_code}\n" -X POST "http://127.0.0.1:8000/auth/token" -H "Content-Type: application/json" -d '{"username":"admin","password":"admin123"}'

------
https://chatgpt.com/codex/tasks/task_e_68d15c0cb1b88328bc748316bd12e791