### PR TITLE
feat: implement cms frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,30 +1,96 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'
+import { computed } from 'vue'
+import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from './stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const navigation = [
+  { name: 'Home', to: { name: 'Home' } },
+  { name: 'แดชบอร์ด', to: { name: 'Dashboard' }, requiresAuth: true },
+]
+
+const isActive = (target) => route.name === target
+
+const filteredNavigation = computed(() =>
+  navigation.filter((item) => !item.requiresAuth || authStore.isAuthenticated)
+)
+
+const handleLogout = () => {
+  authStore.logout()
+  router.push({ name: 'Home' })
+}
+
+const currentYear = new Date().getFullYear()
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
-  </div>
-  <HelloWorld msg="Vite + Vue" />
-</template>
+  <div class="min-h-screen bg-slate-950 text-slate-100 flex flex-col">
+    <header class="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+      <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+        <RouterLink
+          :to="{ name: 'Home' }"
+          class="flex items-center gap-3 text-lg font-semibold tracking-tight text-sky-300"
+        >
+          <span
+            class="grid h-11 w-11 place-items-center rounded-xl bg-gradient-to-br from-sky-400 via-blue-500 to-indigo-600 font-bold text-slate-900 shadow-lg shadow-sky-500/40"
+          >
+            CMS
+          </span>
+          <span>
+            Mini CMS
+            <span class="block text-xs font-normal text-slate-400">ข่าวสาร & ไฟล์แนบ</span>
+          </span>
+        </RouterLink>
 
-<style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
-}
-</style>
+        <nav class="hidden items-center gap-1 rounded-full border border-slate-800 bg-slate-900/70 p-1 text-sm font-medium sm:flex">
+          <RouterLink
+            v-for="item in filteredNavigation"
+            :key="item.name"
+            :to="item.to"
+            class="rounded-full px-4 py-2 transition hover:bg-slate-800 hover:text-white"
+            :class="isActive(item.to.name) ? 'bg-slate-100 text-slate-900' : 'text-slate-300'"
+          >
+            {{ item.name }}
+          </RouterLink>
+        </nav>
+
+        <div class="flex items-center gap-3 text-sm">
+          <template v-if="authStore.isAuthenticated">
+            <span class="hidden text-slate-300 sm:block">
+              ลงชื่อเข้าใช้ในชื่อ <span class="font-semibold text-sky-300">{{ authStore.username }}</span>
+            </span>
+            <button
+              class="rounded-full bg-sky-500 px-4 py-2 font-semibold text-slate-900 shadow-lg shadow-sky-500/30 transition hover:bg-sky-400"
+              type="button"
+              @click="handleLogout"
+            >
+              ออกจากระบบ
+            </button>
+          </template>
+          <template v-else>
+            <RouterLink
+              :to="{ name: 'Login' }"
+              class="rounded-full bg-sky-500 px-4 py-2 font-semibold text-slate-900 shadow-lg shadow-sky-500/30 transition hover:bg-sky-400"
+            >
+              เข้าสู่ระบบ
+            </RouterLink>
+          </template>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1">
+      <RouterView />
+    </main>
+
+    <footer class="border-t border-slate-800 bg-slate-950/80">
+      <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+        <p>© {{ currentYear }} Mini CMS. All rights reserved.</p>
+        <p class="text-slate-400">ออกแบบเพื่อแสดงข่าวและจัดการไฟล์แนบของระบบภายในองค์กร</p>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,26 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', 'Sarabun', 'Prompt', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #05080f;
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+}
+
+button:focus,
+input:focus,
+textarea:focus {
+  outline: none;
+  box-shadow: none;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,8 @@ import App from './App.vue'
 import './index.css'
 
 const app = createApp(App)
+
 app.use(createPinia())
 app.use(router)
+
 app.mount('#app')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,16 +2,45 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import Login from '../views/Login.vue'
 import Dashboard from '../views/Dashboard.vue'
-
-const routes = [
-  { path: '/', name: 'Home', component: Home },
-  { path: '/login', name: 'Login', component: Login },
-  { path: '/admin', name: 'Dashboard', component: Dashboard },
-]
+import { useAuthStore } from '../stores/auth'
 
 const router = createRouter({
   history: createWebHistory(),
-  routes,
+  routes: [
+    { path: '/', name: 'Home', component: Home, meta: { title: 'หน้าแรก' } },
+    { path: '/login', name: 'Login', component: Login, meta: { title: 'เข้าสู่ระบบ' } },
+    {
+      path: '/admin',
+      name: 'Dashboard',
+      component: Dashboard,
+      meta: { requiresAuth: true, title: 'แดชบอร์ดผู้ดูแล' },
+    },
+  ],
+  scrollBehavior() {
+    return { top: 0 }
+  },
+})
+
+router.beforeEach((to) => {
+  const authStore = useAuthStore()
+  if (to.meta?.requiresAuth && !authStore.isAuthenticated) {
+    return {
+      name: 'Login',
+      query: { redirect: to.fullPath },
+    }
+  }
+  if (to.name === 'Login' && authStore.isAuthenticated) {
+    return { name: 'Dashboard' }
+  }
+  return true
+})
+
+router.afterEach((to) => {
+  if (to.meta?.title) {
+    document.title = `${to.meta.title} | Mini CMS`
+  } else {
+    document.title = 'Mini CMS'
+  }
 })
 
 export default router

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,30 @@
+import axios from 'axios'
+
+const baseURL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '')
+
+const api = axios.create({
+  baseURL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  timeout: 15000,
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('mini-cms-token')
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export const resolveFileUrl = (filepath) => {
+  if (!filepath) return '#'
+  if (/^https?:/i.test(filepath)) {
+    return filepath
+  }
+  const sanitized = filepath.startsWith('/') ? filepath : `/${filepath}`
+  return `${baseURL}${sanitized}`
+}
+
+export default api

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,0 +1,71 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import api from '../services/api'
+
+const TOKEN_KEY = 'mini-cms-token'
+const USERNAME_KEY = 'mini-cms-username'
+
+export const useAuthStore = defineStore('auth', () => {
+  const token = ref(localStorage.getItem(TOKEN_KEY) || '')
+  const username = ref(localStorage.getItem(USERNAME_KEY) || '')
+  const loading = ref(false)
+  const error = ref('')
+
+  const isAuthenticated = computed(() => Boolean(token.value))
+
+  const setSession = (accessToken, name) => {
+    token.value = accessToken
+    username.value = name
+    if (accessToken) {
+      localStorage.setItem(TOKEN_KEY, accessToken)
+      api.defaults.headers.common.Authorization = `Bearer ${accessToken}`
+    } else {
+      localStorage.removeItem(TOKEN_KEY)
+      delete api.defaults.headers.common.Authorization
+    }
+
+    if (name) {
+      localStorage.setItem(USERNAME_KEY, name)
+    } else {
+      localStorage.removeItem(USERNAME_KEY)
+    }
+  }
+
+  if (token.value) {
+    api.defaults.headers.common.Authorization = `Bearer ${token.value}`
+  }
+
+  const login = async ({ username: user, password }) => {
+    loading.value = true
+    error.value = ''
+    try {
+      const { data } = await api.post('/auth/login', { username: user, password })
+      if (!data?.access_token) {
+        throw new Error('ไม่สามารถรับโทเค็นจากเซิร์ฟเวอร์ได้')
+      }
+      setSession(data.access_token, user)
+      return data
+    } catch (err) {
+      const message =
+        err.response?.data?.detail || err.message || 'เกิดข้อผิดพลาดในการเข้าสู่ระบบ'
+      error.value = message
+      throw new Error(message)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const logout = () => {
+    setSession('', '')
+  }
+
+  return {
+    token,
+    username,
+    loading,
+    error,
+    isAuthenticated,
+    login,
+    logout,
+  }
+})

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -1,0 +1,318 @@
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import api, { resolveFileUrl } from '../services/api'
+import { useAuthStore } from '../stores/auth'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const news = ref([])
+const loading = ref(true)
+const error = ref('')
+const refreshing = ref(false)
+const createState = reactive({ title: '', content: '' })
+const createLoading = ref(false)
+const createMessage = ref('')
+const uploadState = reactive({})
+
+const hasNews = computed(() => news.value.length > 0)
+
+const formatDate = (value) =>
+  new Intl.DateTimeFormat('th-TH', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+
+const handleUnauthorized = () => {
+  authStore.logout()
+  router.push({ name: 'Login', query: { redirect: '/admin' } })
+}
+
+const fetchNews = async () => {
+  if (!refreshing.value) {
+    loading.value = true
+  }
+  error.value = ''
+  try {
+    const { data } = await api.get('/news/')
+    news.value = data
+  } catch (err) {
+    if (err.response?.status === 401) {
+      handleUnauthorized()
+    } else {
+      error.value = err.response?.data?.detail || err.message || 'ไม่สามารถโหลดข่าวได้'
+    }
+  } finally {
+    loading.value = false
+    refreshing.value = false
+  }
+}
+
+const refresh = async () => {
+  refreshing.value = true
+  await fetchNews()
+}
+
+const resetCreateForm = () => {
+  createState.title = ''
+  createState.content = ''
+}
+
+const handleCreate = async () => {
+  if (!createState.title.trim() || !createState.content.trim()) {
+    createMessage.value = 'กรุณากรอกหัวข้อและเนื้อหาให้ครบถ้วน'
+    return
+  }
+  createLoading.value = true
+  createMessage.value = ''
+  try {
+    const { data } = await api.post('/news/', {
+      title: createState.title.trim(),
+      content: createState.content.trim(),
+    })
+    news.value = [data, ...news.value]
+    createMessage.value = 'บันทึกข่าวสำเร็จ'
+    resetCreateForm()
+  } catch (err) {
+    if (err.response?.status === 401) {
+      handleUnauthorized()
+      return
+    }
+    createMessage.value = err.response?.data?.detail || err.message || 'ไม่สามารถบันทึกข่าวได้'
+  } finally {
+    createLoading.value = false
+  }
+}
+
+const handleUpload = async (newsId, file) => {
+  if (!file) {
+    uploadState[newsId] = { message: 'กรุณาเลือกไฟล์ก่อน', status: 'error', loading: false }
+    return
+  }
+  uploadState[newsId] = { loading: true, message: '', status: 'info' }
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const { data } = await api.post(`/news/${newsId}/files`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    const target = news.value.find((item) => item.id === newsId)
+    if (target) {
+      target.files = target.files ? [data, ...target.files] : [data]
+    }
+    uploadState[newsId] = { loading: false, message: 'อัปโหลดไฟล์สำเร็จ', status: 'success' }
+  } catch (err) {
+    if (err.response?.status === 401) {
+      handleUnauthorized()
+      return
+    }
+    uploadState[newsId] = {
+      loading: false,
+      message: err.response?.data?.detail || err.message || 'อัปโหลดไฟล์ไม่สำเร็จ',
+      status: 'error',
+    }
+  }
+}
+
+const onFileChange = (event, newsId) => {
+  const file = event.target.files?.[0]
+  if (!file) {
+    return
+  }
+  handleUpload(newsId, file)
+  event.target.value = ''
+}
+
+onMounted(fetchNews)
+</script>
+
+<template>
+  <div class="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-12 sm:px-6 lg:px-8">
+    <section class="rounded-3xl border border-emerald-500/30 bg-gradient-to-br from-slate-900 via-slate-950 to-black p-10 shadow-2xl shadow-emerald-500/10">
+      <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div class="space-y-4 md:max-w-2xl">
+          <span class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
+            Admin Workspace
+          </span>
+          <h1 class="text-3xl font-semibold text-white sm:text-4xl">แดชบอร์ดจัดการข่าวสาร</h1>
+          <p class="text-sm leading-relaxed text-slate-300 sm:text-base">
+            สร้างและเผยแพร่ข่าวสารสำคัญ พร้อมแนบเอกสารที่เกี่ยวข้อง อัปเดตข้อมูลให้ทันสมัย เพื่อให้บุคลากรเข้าถึงข่าวสารล่าสุดได้เสมอ
+          </p>
+        </div>
+        <div class="grid gap-4 rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-6 text-sm text-emerald-100">
+          <div>
+            <p class="text-xs uppercase tracking-[0.2em] text-emerald-300/70">ผู้ใช้งานปัจจุบัน</p>
+            <p class="text-2xl font-semibold text-white">{{ authStore.username }}</p>
+          </div>
+          <button
+            type="button"
+            class="flex items-center justify-center gap-2 rounded-full border border-emerald-400/60 bg-emerald-500/20 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-400/30"
+            @click="refresh"
+            :disabled="loading || refreshing"
+          >
+            <span v-if="refreshing" class="h-4 w-4 animate-spin rounded-full border-2 border-emerald-200 border-t-transparent"></span>
+            <span>{{ refreshing ? 'กำลังรีเฟรช' : 'รีเฟรชรายการข่าว' }}</span>
+          </button>
+          <p class="text-xs text-emerald-200/70">ระบบจะรีเฟรชอัตโนมัติหลังจากเพิ่มข่าวหรือไฟล์ใหม่</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
+      <div class="space-y-6">
+        <header class="flex flex-col gap-2">
+          <h2 class="text-xl font-semibold text-white">รายการข่าวที่เผยแพร่</h2>
+          <p class="text-sm text-slate-400">จัดการไฟล์แนบของข่าวแต่ละรายการได้จากที่นี่</p>
+        </header>
+
+        <div v-if="loading" class="grid gap-4">
+          <div v-for="index in 3" :key="index" class="animate-pulse rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+            <div class="h-5 w-2/3 rounded bg-slate-700/60"></div>
+            <div class="mt-3 h-20 rounded bg-slate-800/60"></div>
+          </div>
+        </div>
+
+        <div v-else-if="error" class="rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-red-200">
+          {{ error }}
+        </div>
+
+        <div v-else-if="!hasNews" class="grid place-items-center rounded-2xl border border-slate-800 bg-slate-900/60 p-16 text-center text-slate-400">
+          <div class="space-y-3">
+            <p class="text-lg font-semibold text-slate-200">ยังไม่มีข่าวในระบบ</p>
+            <p>สร้างข่าวฉบับแรกจากแบบฟอร์มด้านขวา</p>
+          </div>
+        </div>
+
+        <div v-else class="space-y-5">
+          <article
+            v-for="item in news"
+            :key="item.id"
+            class="rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-lg shadow-emerald-500/5"
+          >
+            <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div class="space-y-2">
+                <p class="text-xs uppercase tracking-[0.25em] text-slate-500">รหัสข่าว #{{ item.id }}</p>
+                <h3 class="text-2xl font-semibold text-white">{{ item.title }}</h3>
+                <p class="whitespace-pre-wrap text-sm leading-relaxed text-slate-300">{{ item.content }}</p>
+              </div>
+              <div class="flex flex-col items-end gap-2 text-right text-xs text-slate-500">
+                <span class="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/70 px-3 py-1 text-slate-300">
+                  เผยแพร่ {{ formatDate(item.created_at) }}
+                </span>
+                <span v-if="item.updated_at">แก้ไขล่าสุด {{ formatDate(item.updated_at) }}</span>
+              </div>
+            </div>
+
+            <div class="mt-6 space-y-4">
+              <div class="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-950/60 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div class="space-y-1">
+                  <p class="text-sm font-medium text-slate-100">อัปโหลดไฟล์แนบ</p>
+                  <p class="text-xs text-slate-400">รองรับไฟล์ทุกประเภท ขนาดตามที่เซิร์ฟเวอร์กำหนด</p>
+                </div>
+                <label class="inline-flex cursor-pointer items-center gap-3 rounded-full bg-emerald-500/20 px-4 py-2 text-sm font-medium text-emerald-100 shadow-inner shadow-emerald-500/20 transition hover:bg-emerald-400/30">
+                  <input type="file" class="hidden" @change="(event) => onFileChange(event, item.id)" />
+                  <span>เลือกไฟล์</span>
+                </label>
+              </div>
+
+              <div v-if="uploadState[item.id]?.message" :class="[
+                'rounded-2xl px-4 py-3 text-sm',
+                uploadState[item.id]?.status === 'success'
+                  ? 'border border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                  : 'border border-red-500/40 bg-red-500/10 text-red-100',
+              ]">
+                {{ uploadState[item.id]?.message }}
+              </div>
+
+              <div v-if="item.files?.length" class="space-y-3">
+                <p class="text-sm font-medium text-slate-200">ไฟล์ทั้งหมด {{ item.files.length }} รายการ</p>
+                <ul class="grid gap-3 sm:grid-cols-2">
+                  <li
+                    v-for="file in item.files"
+                    :key="file.id"
+                    class="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300"
+                  >
+                    <div>
+                      <p class="font-medium text-slate-100">{{ file.filename }}</p>
+                      <p class="text-xs text-slate-500">อัปโหลด {{ formatDate(file.uploaded_at) }}</p>
+                    </div>
+                    <a
+                      :href="resolveFileUrl(file.filepath)"
+                      class="text-xs font-semibold uppercase tracking-wider text-emerald-300 hover:text-emerald-200"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      เปิดดู
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <aside class="space-y-6">
+        <div class="rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-xl shadow-emerald-500/10">
+          <h2 class="text-xl font-semibold text-white">สร้างข่าวใหม่</h2>
+          <p class="mt-1 text-sm text-slate-400">ระบุหัวข้อและรายละเอียดข่าว พร้อมตรวจสอบความถูกต้องก่อนกดเผยแพร่</p>
+
+          <form class="mt-6 space-y-5" @submit.prevent="handleCreate">
+            <div class="space-y-2">
+              <label class="block text-sm font-medium text-slate-200" for="title">หัวข้อข่าว</label>
+              <input
+                id="title"
+                v-model="createState.title"
+                type="text"
+                required
+                class="w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="เช่น แจ้งปิดระบบประจำเดือน"
+              />
+            </div>
+
+            <div class="space-y-2">
+              <label class="block text-sm font-medium text-slate-200" for="content">รายละเอียดข่าว</label>
+              <textarea
+                id="content"
+                v-model="createState.content"
+                rows="6"
+                required
+                class="w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="อธิบายข้อมูลเพิ่มเติม เช่น วันเวลา เนื้อหา และลิงก์ที่เกี่ยวข้อง"
+              ></textarea>
+            </div>
+
+            <div
+              v-if="createMessage"
+              class="rounded-2xl border px-4 py-3 text-sm"
+              :class="createMessage === 'บันทึกข่าวสำเร็จ'
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                : 'border-red-500/40 bg-red-500/10 text-red-100'"
+            >
+              {{ createMessage }}
+            </div>
+
+            <button
+              type="submit"
+              class="w-full rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              :disabled="createLoading"
+            >
+              <span v-if="createLoading" class="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-slate-900 border-t-transparent"></span>
+              บันทึกข่าวและเผยแพร่
+            </button>
+          </form>
+        </div>
+
+        <div class="rounded-3xl border border-slate-800 bg-slate-950/70 p-6 text-xs text-slate-400">
+          <h3 class="text-sm font-semibold text-slate-200">คำแนะนำในการเขียนข่าว</h3>
+          <ul class="mt-3 space-y-2">
+            <li>• ใช้ภาษากระชับ เข้าใจง่าย และระบุวันเวลาให้ชัดเจน</li>
+            <li>• หากมีไฟล์แนบ ให้ตั้งชื่อไฟล์สื่อถึงเนื้อหาและเวอร์ชัน</li>
+            <li>• สามารถอัปเดตแก้ไขข้อมูลได้จากฝั่ง Backend หากมีการเปลี่ยนแปลง</li>
+          </ul>
+        </div>
+      </aside>
+    </section>
+  </div>
+</template>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,0 +1,188 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import api, { resolveFileUrl } from '../services/api'
+
+const news = ref([])
+const loading = ref(true)
+const refreshing = ref(false)
+const error = ref('')
+
+const newsCount = computed(() => news.value.length)
+
+const formatDate = (value) =>
+  new Intl.DateTimeFormat('th-TH', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(new Date(value))
+
+const fetchNews = async () => {
+  if (loading.value) {
+    error.value = ''
+  }
+  try {
+    const { data } = await api.get('/news/')
+    news.value = data
+  } catch (err) {
+    error.value = err.response?.data?.detail || err.message || 'โหลดข้อมูลไม่สำเร็จ'
+  } finally {
+    loading.value = false
+    refreshing.value = false
+  }
+}
+
+const refresh = async () => {
+  refreshing.value = true
+  await fetchNews()
+}
+
+onMounted(fetchNews)
+</script>
+
+<template>
+  <div class="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-10 sm:px-6 lg:px-8">
+    <section class="grid gap-8 rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-slate-950 to-black p-10 text-slate-100 shadow-2xl shadow-sky-500/5">
+      <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div class="space-y-4 lg:max-w-2xl">
+          <span class="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-300">
+            MINI CMS HUB
+          </span>
+          <h1 class="text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+            ศูนย์กลางเผยแพร่ข่าวสารและเอกสารสำคัญของหน่วยงาน
+          </h1>
+          <p class="text-base text-slate-300 sm:text-lg">
+            รวบรวมประกาศ แจ้งเตือน และไฟล์แนบล่าสุดไว้ในที่เดียว เพื่อให้ทีมงานทุกคนเข้าถึงข้อมูลสำคัญได้อย่างรวดเร็วและปลอดภัย
+          </p>
+        </div>
+        <div class="grid gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+          <div>
+            <p class="text-xs uppercase tracking-[0.2em] text-slate-500">จำนวนข่าวทั้งหมด</p>
+            <p class="text-4xl font-semibold text-sky-300">{{ newsCount }}</p>
+          </div>
+          <button
+            type="button"
+            class="flex items-center justify-center gap-2 rounded-full bg-sky-500 px-4 py-2 font-medium text-slate-900 transition hover:bg-sky-400"
+            @click="refresh"
+            :disabled="loading || refreshing"
+          >
+            <span v-if="refreshing" class="h-4 w-4 animate-spin rounded-full border-2 border-slate-900 border-t-transparent"></span>
+            <span>{{ refreshing ? 'กำลังอัปเดต' : 'รีเฟรชข้อมูลล่าสุด' }}</span>
+          </button>
+          <p class="text-xs text-slate-500">
+            ข้อมูลถูกอัปเดตโดยอัตโนมัติจากระบบจัดการข่าวของผู้ดูแล หากต้องการเพิ่มข่าวใหม่ต้องเข้าสู่ระบบในโหมดผู้ดูแล
+          </p>
+        </div>
+      </div>
+      <div class="grid gap-3 text-xs text-slate-500 sm:grid-cols-3">
+        <div class="rounded-2xl border border-slate-800/70 bg-slate-900/30 p-4">
+          <p class="text-slate-400">พร้อมสำหรับ Mobile</p>
+          <p class="mt-1 text-base font-medium text-slate-200">ออกแบบแบบ Responsive รองรับทุกหน้าจอ</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800/70 bg-slate-900/30 p-4">
+          <p class="text-slate-400">ไฟล์แนบปลอดภัย</p>
+          <p class="mt-1 text-base font-medium text-slate-200">รองรับเอกสารแนบและลิงก์ดาวน์โหลด</p>
+        </div>
+        <div class="rounded-2xl border border-slate-800/70 bg-slate-900/30 p-4">
+          <p class="text-slate-400">เชื่อมต่อ API</p>
+          <p class="mt-1 text-base font-medium text-slate-200">ดึงข้อมูลข่าวจาก Mini CMS Backend</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <header class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 class="text-2xl font-semibold text-white">ข่าวสารล่าสุด</h2>
+          <p class="text-sm text-slate-400">อัปเดตเรียลไทม์จากระบบ Mini CMS Backend</p>
+        </div>
+        <RouterLink
+          :to="{ name: 'Dashboard' }"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/70 px-4 py-2 text-sm font-medium text-sky-200 transition hover:border-sky-500/40 hover:bg-sky-500/10"
+        >
+          สำหรับผู้ดูแลระบบ
+        </RouterLink>
+      </header>
+
+      <div v-if="loading" class="grid gap-4">
+        <div
+          v-for="index in 3"
+          :key="index"
+          class="animate-pulse rounded-2xl border border-slate-800 bg-slate-900/50 p-6"
+        >
+          <div class="h-4 w-1/3 rounded bg-slate-700/60"></div>
+          <div class="mt-4 h-6 w-2/3 rounded bg-slate-700/60"></div>
+          <div class="mt-4 h-24 rounded bg-slate-800/60"></div>
+        </div>
+      </div>
+
+      <div v-else-if="error" class="rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-red-200">
+        {{ error }}
+      </div>
+
+      <div v-else-if="!news.length" class="grid place-items-center rounded-2xl border border-slate-800 bg-slate-900/60 p-16 text-center text-slate-400">
+        <div class="space-y-2">
+          <p class="text-lg font-semibold text-slate-200">ยังไม่มีข่าวในระบบ</p>
+          <p>เข้าสู่ระบบผู้ดูแลเพื่อเพิ่มข่าวสารฉบับแรก</p>
+        </div>
+      </div>
+
+      <div v-else class="grid gap-6">
+        <article
+          v-for="item in news"
+          :key="item.id"
+          class="group rounded-3xl border border-slate-800 bg-slate-900/50 p-8 transition hover:border-sky-500/40 hover:bg-slate-900/80"
+        >
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-3">
+              <p class="text-xs uppercase tracking-[0.25em] text-slate-500">#{{ item.id }}</p>
+              <h3 class="text-2xl font-semibold text-white transition group-hover:text-sky-300">
+                {{ item.title }}
+              </h3>
+              <p class="whitespace-pre-wrap text-sm leading-relaxed text-slate-300">
+                {{ item.content }}
+              </p>
+            </div>
+            <div class="flex flex-col items-end gap-2 text-right text-sm text-slate-400">
+              <span class="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/60 px-3 py-1">
+                <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                เผยแพร่เมื่อ {{ formatDate(item.created_at) }}
+              </span>
+              <span v-if="item.updated_at" class="text-xs text-slate-500">
+                แก้ไขล่าสุด {{ formatDate(item.updated_at) }}
+              </span>
+            </div>
+          </div>
+
+          <div v-if="item.files?.length" class="mt-6 space-y-3">
+            <p class="text-sm font-medium text-slate-200">ไฟล์แนบ</p>
+            <ul class="grid gap-3 sm:grid-cols-2">
+              <li
+                v-for="file in item.files"
+                :key="file.id"
+                class="group/file flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300 transition hover:border-sky-500/30 hover:bg-sky-500/10"
+              >
+                <div class="flex items-center gap-3">
+                  <span class="grid h-10 w-10 place-items-center rounded-full bg-slate-800/80 text-sky-300 group-hover/file:bg-sky-500/20">
+                    📎
+                  </span>
+                  <div>
+                    <p class="font-medium text-slate-100 group-hover/file:text-sky-200">{{ file.filename }}</p>
+                    <p class="text-xs text-slate-500">อัปโหลดเมื่อ {{ formatDate(file.uploaded_at) }}</p>
+                  </div>
+                </div>
+                <a
+                  :href="resolveFileUrl(file.filepath)"
+                  class="text-xs font-semibold uppercase tracking-wider text-sky-300 hover:text-sky-200"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  ดาวน์โหลด
+                </a>
+              </li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+  </div>
+</template>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+
+const router = useRouter()
+const route = useRoute()
+const authStore = useAuthStore()
+const form = reactive({ username: '', password: '' })
+const showPassword = ref(false)
+const submitError = ref('')
+
+const handleSubmit = async () => {
+  submitError.value = ''
+  try {
+    await authStore.login(form)
+    router.push(route.query.redirect || { name: 'Dashboard' })
+  } catch (err) {
+    submitError.value = err.message
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto grid max-w-5xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-16">
+    <section class="space-y-6">
+      <span class="inline-flex items-center gap-2 rounded-full border border-purple-500/40 bg-purple-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-purple-200">
+        Secure Access
+      </span>
+      <h1 class="text-3xl font-semibold text-white sm:text-4xl">เข้าสู่ระบบผู้ดูแล Mini CMS</h1>
+      <p class="text-sm leading-relaxed text-slate-300 sm:text-base">
+        จัดการข่าวสาร สร้างประกาศใหม่ และแนบไฟล์ให้บุคลากรดาวน์โหลดได้จากศูนย์กลางเดียว ตรวจสอบความถูกต้องก่อนเผยแพร่เพื่อให้ข้อมูลที่ส่งถึงผู้รับมีความน่าเชื่อถือที่สุด
+      </p>
+      <div class="rounded-2xl border border-purple-500/30 bg-purple-500/10 p-5 text-sm text-purple-100">
+        <p class="font-medium">บัญชีเริ่มต้นสำหรับทดสอบ</p>
+        <p class="mt-1 text-xs text-purple-200/80">username: <span class="font-semibold">admin</span> · password: <span class="font-semibold">admin123</span></p>
+        <p class="mt-3 text-xs text-purple-200/70">สามารถเปลี่ยนรหัสผ่านได้จากฝั่ง Backend (ไฟล์ .env)</p>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-slate-800 bg-slate-900/80 p-8 shadow-2xl shadow-purple-500/10 backdrop-blur">
+      <form class="space-y-6" @submit.prevent="handleSubmit">
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-slate-200" for="username">ชื่อผู้ใช้</label>
+          <input
+            id="username"
+            v-model="form.username"
+            type="text"
+            required
+            class="w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 focus:border-purple-400 focus:ring-2 focus:ring-purple-400/40"
+            placeholder="เช่น admin"
+          />
+        </div>
+
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-slate-200" for="password">รหัสผ่าน</label>
+          <div class="relative">
+            <input
+              id="password"
+              v-model="form.password"
+              :type="showPassword ? 'text' : 'password'"
+              required
+              class="w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-3 pr-12 text-sm text-slate-100 focus:border-purple-400 focus:ring-2 focus:ring-purple-400/40"
+              placeholder="รหัสผ่านของผู้ดูแล"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-3 flex items-center text-xs font-semibold uppercase tracking-wide text-purple-200"
+              @click="showPassword = !showPassword"
+            >
+              {{ showPassword ? 'ซ่อน' : 'แสดง' }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="submitError" class="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {{ submitError }}
+        </div>
+
+        <button
+          type="submit"
+          class="w-full rounded-2xl bg-gradient-to-r from-purple-500 via-sky-500 to-blue-500 px-4 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-purple-500/20 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="authStore.loading"
+        >
+          <span v-if="authStore.loading" class="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-slate-900 border-t-transparent"></span>
+          เข้าสู่ระบบ
+        </button>
+
+        <p class="text-center text-xs text-slate-500">
+          ระบบนี้สำหรับผู้ดูแลระบบเท่านั้น หากไม่มีบัญชี โปรดติดต่อแอดมินของระบบเพื่อขอสิทธิ์การใช้งาน
+        </p>
+      </form>
+    </section>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- implement the new application shell with navigation, footer, and Tailwind-driven global styling
- wire up authentication, API client helpers, and routing guards for the Mini CMS frontend
- add Home, Login, and Admin Dashboard screens for browsing, publishing, and attaching files to news items

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15f9d7ee083289f258686a843c245