### PR TITLE
Add image attachment support and previews

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,12 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+
 from . import models, database, auth
 from .routers import news, auth as auth_router
-from sqlalchemy.orm import Session
-import os
 
 models.Base.metadata.create_all(bind=database.engine)
 
@@ -34,6 +37,10 @@ app.add_middleware(
 # รวม router
 app.include_router(auth_router.router)
 app.include_router(news.router)
+
+upload_dir = os.getenv("UPLOAD_DIR", "uploads")
+os.makedirs(upload_dir, exist_ok=True)
+app.mount("/uploads", StaticFiles(directory=upload_dir), name="uploads")
 
 @app.on_event("startup")
 def init_admin():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,8 @@
+import os
+
 from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, func
 from sqlalchemy.orm import relationship
+
 from .database import Base
 
 class User(Base):
@@ -28,3 +31,11 @@ class File(Base):
     uploaded_at = Column(DateTime(timezone=True), server_default=func.now())
 
     news = relationship("News", back_populates="files")
+
+    @property
+    def is_image(self) -> bool:
+        """Return True when the stored file is likely an image."""
+        if not self.filename:
+            return False
+        _, ext = os.path.splitext(self.filename.lower())
+        return ext in {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg"}

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -1,10 +1,13 @@
+import os
+import shutil
+import uuid
+
 from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
 from sqlalchemy.orm import Session
 from .. import database, models, schemas, auth
-import shutil, os
 
 router = APIRouter(prefix="/news", tags=["News"])
-UPLOAD_DIR = "uploads"
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "uploads")
 
 @router.get("/", response_model=list[schemas.NewsBase])
 def get_news(db: Session = Depends(database.get_db)):
@@ -20,11 +23,30 @@ def create_news(news: schemas.NewsCreate, db: Session = Depends(database.get_db)
 
 @router.post("/{news_id}/files", response_model=schemas.FileBase)
 def upload_file(news_id: int, file: UploadFile = File(...), db: Session = Depends(database.get_db), current_user: models.User = Depends(auth.get_current_user)):
+    target_news = db.query(models.News).filter(models.News.id == news_id).first()
+    if not target_news:
+        raise HTTPException(status_code=404, detail="ไม่พบบทความข่าว")
+
+    original_name = os.path.basename(file.filename)
+    if not original_name:
+        raise HTTPException(status_code=400, detail="ชื่อไฟล์ไม่ถูกต้อง")
+
     os.makedirs(UPLOAD_DIR, exist_ok=True)
-    file_path = os.path.join(UPLOAD_DIR, file.filename)
-    with open(file_path, "wb") as buffer:
-        shutil.copyfileobj(file.file, buffer)
-    new_file = models.File(news_id=news_id, filename=file.filename, filepath=file_path)
+
+    name, ext = os.path.splitext(original_name)
+    sanitized_name = "".join(char if char.isalnum() or char in {"-", "_"} else "_" for char in name).strip("._") or "file"
+    unique_name = f"{uuid.uuid4().hex}_{sanitized_name}{ext.lower()}"
+    file_path = os.path.join(UPLOAD_DIR, unique_name)
+
+    try:
+        with open(file_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail="บันทึกไฟล์ไม่สำเร็จ") from exc
+    finally:
+        file.file.close()
+
+    new_file = models.File(news_id=news_id, filename=original_name, filepath=file_path)
     db.add(new_file)
     db.commit()
     db.refresh(new_file)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,6 +7,7 @@ class FileBase(BaseModel):
     filename: str
     filepath: str
     uploaded_at: datetime
+    is_image: bool = False
     class Config:
         from_attributes = True
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -18,6 +18,9 @@ const uploadState = reactive({})
 
 const hasNews = computed(() => news.value.length > 0)
 
+const imageFiles = (files) => (files || []).filter((file) => file?.is_image)
+const otherFiles = (files) => (files || []).filter((file) => !file?.is_image)
+
 const formatDate = (value) =>
   new Intl.DateTimeFormat('th-TH', {
     dateStyle: 'medium',
@@ -225,11 +228,27 @@ onMounted(fetchNews)
                 {{ uploadState[item.id]?.message }}
               </div>
 
-              <div v-if="item.files?.length" class="space-y-3">
-                <p class="text-sm font-medium text-slate-200">ไฟล์ทั้งหมด {{ item.files.length }} รายการ</p>
+              <div v-if="imageFiles(item.files).length" class="space-y-3">
+                <p class="text-sm font-medium text-slate-200">รูปภาพประกอบ</p>
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <figure
+                    v-for="file in imageFiles(item.files)"
+                    :key="`image-${file.id}`"
+                    class="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/60"
+                  >
+                    <img :src="resolveFileUrl(file.filepath)" :alt="file.filename" class="h-48 w-full object-cover" />
+                    <figcaption class="border-t border-slate-800/60 px-4 py-2 text-xs text-slate-400">
+                      {{ file.filename }}
+                    </figcaption>
+                  </figure>
+                </div>
+              </div>
+
+              <div v-if="otherFiles(item.files).length" class="space-y-3">
+                <p class="text-sm font-medium text-slate-200">ไฟล์แนบอื่น ๆ {{ otherFiles(item.files).length }} รายการ</p>
                 <ul class="grid gap-3 sm:grid-cols-2">
                   <li
-                    v-for="file in item.files"
+                    v-for="file in otherFiles(item.files)"
                     :key="file.id"
                     class="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300"
                   >

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,6 +10,9 @@ const error = ref('')
 
 const newsCount = computed(() => news.value.length)
 
+const imageFiles = (files) => (files || []).filter((file) => file?.is_image)
+const otherFiles = (files) => (files || []).filter((file) => !file?.is_image)
+
 const formatDate = (value) =>
   new Intl.DateTimeFormat('th-TH', {
     dateStyle: 'long',
@@ -153,11 +156,27 @@ onMounted(fetchNews)
             </div>
           </div>
 
-          <div v-if="item.files?.length" class="mt-6 space-y-3">
-            <p class="text-sm font-medium text-slate-200">ไฟล์แนบ</p>
+          <div v-if="imageFiles(item.files).length" class="mt-6 space-y-3">
+            <p class="text-sm font-medium text-slate-200">รูปภาพประกอบ</p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <figure
+                v-for="file in imageFiles(item.files)"
+                :key="`image-${file.id}`"
+                class="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/60"
+              >
+                <img :src="resolveFileUrl(file.filepath)" :alt="file.filename" class="h-56 w-full object-cover" />
+                <figcaption class="border-t border-slate-800/60 px-4 py-2 text-xs text-slate-400">
+                  {{ file.filename }}
+                </figcaption>
+              </figure>
+            </div>
+          </div>
+
+          <div v-if="otherFiles(item.files).length" class="mt-6 space-y-3">
+            <p class="text-sm font-medium text-slate-200">ไฟล์แนบอื่น ๆ</p>
             <ul class="grid gap-3 sm:grid-cols-2">
               <li
-                v-for="file in item.files"
+                v-for="file in otherFiles(item.files)"
                 :key="file.id"
                 class="group/file flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300 transition hover:border-sky-500/30 hover:bg-sky-500/10"
               >


### PR DESCRIPTION
## Summary
- serve uploaded assets from the backend and harden upload handling with unique filenames
- expose an `is_image` flag so clients can distinguish pictures from other files
- render image galleries on the public home page and admin dashboard alongside existing attachments

## Testing
- npm run build
- python -m compileall app


------
https://chatgpt.com/codex/tasks/task_e_68d165afb6f0832882ef3f3d2a1c544b