### PR TITLE
Add frontend Dockerfile and expose Vite dev server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend:/app
-    command: npm run dev
+    command: npm run dev -- --host 0.0.0.0

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+/dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the frontend service so docker compose builds succeed
- ignore node_modules and dist when building the frontend image
- update the frontend compose command to bind the Vite dev server to 0.0.0.0

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d746b3bf748328910f3e39d8740718