### PR TITLE
Fix Rollup native module error in frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     command: npm run dev -- --host 0.0.0.0


### PR DESCRIPTION
## Summary
- ensure the frontend service uses a container-managed node_modules volume so Linux-specific optional dependencies stay available when developing with Docker Compose

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d74959cab0832899a5c47c1158e4fc