### PR TITLE
Allow configuring extra CORS origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,10 +21,22 @@ app = FastAPI(
     }
 )
 
-origins = [
+# รวบรวมรายการ origin ที่อนุญาตให้ frontend เรียกใช้งาน API ได้
+# ค่าพื้นฐานจะครอบคลุมการพัฒนาในเครื่องทั่วไป และสามารถปรับเพิ่มได้ผ่าน
+# ตัวแปรสภาพแวดล้อม `CORS_ALLOW_ORIGINS` (คั่นด้วยเครื่องหมายจุลภาค)
+default_origins = {
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-]
+    "http://localhost:4173",
+    "http://127.0.0.1:4173",
+}
+
+extra_origins = os.getenv("CORS_ALLOW_ORIGINS", "")
+if extra_origins:
+    # ตัดช่องว่างและละเว้นค่าเปล่า เพื่อป้องกัน header ที่ไม่ถูกต้อง
+    default_origins.update({origin.strip() for origin in extra_origins.split(",") if origin.strip()})
+
+origins = sorted(default_origins)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- broaden the default list of allowed CORS origins to cover additional local dev ports
- support configuring more allowed origins through the `CORS_ALLOW_ORIGINS` environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7de5ca0648328887654ac5b2f94c5