### PR TITLE
Handle long passwords gracefully during login

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -21,7 +21,20 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def verify_password(password: str, hashed_pw: str) -> bool:
-    return pwd_context.verify(password, hashed_pw)
+    """Return True when the password matches the stored hash.
+
+    ``passlib`` will raise ``ValueError`` when a password longer than the
+    supported bcrypt limit (72 bytes) is supplied.  Instead of bubbling that
+    up and causing a 500 response, treat it as a failed verification so the
+    caller can respond with a normal 401.
+    """
+
+    try:
+        return pwd_context.verify(password, hashed_pw)
+    except ValueError:
+        # Treat overly long passwords (or other value errors) as a
+        # verification failure instead of triggering an internal error.
+        return False
 
 # tokenUrl สำหรับ OAuth2 (endpoint รองรับทั้ง form และ JSON)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")


### PR DESCRIPTION
## Summary
- wrap password verification in a try/except so overly long passwords are treated as invalid credentials instead of crashing the login flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e0376c9c8328a07057fdaea36822