### PR TITLE
Pin bcrypt version for passlib compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart
 passlib[bcrypt]
 python-jose[cryptography]
 pydantic
+bcrypt==3.2.2


### PR DESCRIPTION
## Summary
- pin the bcrypt dependency to 3.2.2 so passlib's bcrypt handler can load without runtime errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e16afc68832882a58696d4d3c5a5