### PR TITLE
Add edit and delete support for news posts

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,7 +20,7 @@ class News(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
-    files = relationship("File", back_populates="news")
+    files = relationship("File", back_populates="news", cascade="all, delete-orphan")
 
 class File(Base):
     __tablename__ = "files"

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import uuid
 
-from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from sqlalchemy.orm import Session
 from .. import database, models, schemas, auth
 
@@ -20,6 +20,41 @@ def create_news(news: schemas.NewsCreate, db: Session = Depends(database.get_db)
     db.commit()
     db.refresh(new_news)
     return new_news
+
+
+@router.put("/{news_id}", response_model=schemas.NewsBase)
+def update_news(
+    news_id: int,
+    news: schemas.NewsUpdate,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    target_news = db.query(models.News).filter(models.News.id == news_id).first()
+    if not target_news:
+        raise HTTPException(status_code=404, detail="ไม่พบบทความข่าว")
+
+    has_changes = False
+
+    if news.title is not None:
+        cleaned_title = news.title.strip()
+        if not cleaned_title:
+            raise HTTPException(status_code=400, detail="หัวข้อข่าวต้องไม่ว่าง")
+        target_news.title = cleaned_title
+        has_changes = True
+
+    if news.content is not None:
+        cleaned_content = news.content.strip()
+        if not cleaned_content:
+            raise HTTPException(status_code=400, detail="เนื้อหาข่าวต้องไม่ว่าง")
+        target_news.content = cleaned_content
+        has_changes = True
+
+    if not has_changes:
+        raise HTTPException(status_code=400, detail="ไม่มีข้อมูลที่ต้องการอัปเดต")
+
+    db.commit()
+    db.refresh(target_news)
+    return target_news
 
 @router.post("/{news_id}/files", response_model=schemas.FileBase)
 def upload_file(news_id: int, file: UploadFile = File(...), db: Session = Depends(database.get_db), current_user: models.User = Depends(auth.get_current_user)):
@@ -51,3 +86,28 @@ def upload_file(news_id: int, file: UploadFile = File(...), db: Session = Depend
     db.commit()
     db.refresh(new_file)
     return new_file
+
+
+@router.delete("/{news_id}", status_code=204)
+def delete_news(
+    news_id: int,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    target_news = db.query(models.News).filter(models.News.id == news_id).first()
+    if not target_news:
+        raise HTTPException(status_code=404, detail="ไม่พบบทความข่าว")
+
+    file_paths = [file.filepath for file in target_news.files]
+
+    db.delete(target_news)
+    db.commit()
+
+    for path in file_paths:
+        if path and os.path.exists(path):
+            try:
+                os.remove(path)
+            except OSError:
+                continue
+
+    return Response(status_code=204)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
-from typing import List, Optional
 from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 
 class FileBase(BaseModel):
     id: int
@@ -8,8 +10,10 @@ class FileBase(BaseModel):
     filepath: str
     uploaded_at: datetime
     is_image: bool = False
+
     class Config:
         from_attributes = True
+
 
 class NewsBase(BaseModel):
     id: int
@@ -17,15 +21,22 @@ class NewsBase(BaseModel):
     content: str
     created_at: datetime
     updated_at: Optional[datetime] = None
-    files: List[FileBase] = []
+    files: List[FileBase] = Field(default_factory=list)
+
     class Config:
         from_attributes = True
+
 
 class NewsCreate(BaseModel):
     title: str
     content: str
 
+
+class NewsUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+
+
 class UserLogin(BaseModel):
     username: str
     password: str
-local_kw: Optional[str] = None  # ✅ ไม่ต้องส่งมาก็ได้


### PR DESCRIPTION
## Summary
- add FastAPI endpoints and schema updates to edit and delete news entries while cleaning up related files
- cascade delete news attachments in the ORM to keep records consistent
- expose inline edit and delete controls in the dashboard UI with feedback for administrators

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7e307bcc48328b447dfa60a302394